### PR TITLE
Update backup

### DIFF
--- a/scripts/backup
+++ b/scripts/backup
@@ -5,6 +5,7 @@ app=kanboard
 # which will be compressed afterward
 backup_dir=$1/apps/$app
 mkdir -p $backup_dir
+sudo chown admin: $backup_dir
 
 # Backup sources & data
 sudo cp -a /var/www/$app/. $backup_dir/sources


### PR DESCRIPTION
chown $backup_dir is a way to fix the sudo mysqldump, which somehow can't write his dump without it.
The column in admin: is equivalent to "user = admin, group = admin's primary group".

With the other PR I just made, it works on my server.

    Exécution du script...
    + app=kanboard
    + backup_dir=/home/yunohost.backup/tmp/test5/apps/kanboard
    + sudo mkdir -p /home/yunohost.backup/tmp/test5/apps/kanboard
    + sudo chown admin: /home/yunohost.backup/tmp/test5/apps/kanboard
    + sudo cp -a /var/www/kanboard/. /home/yunohost.backup/tmp/test5/apps/kanboard/sources
    ++ sudo yunohost app setting kanboard mysqlpwd
    + db_pwd=kkkkkkkk
    + sudo mysqldump -u kanboard -hhhhhhhh kanboard
    + sudo cp -a /etc/yunohost/apps/kanboard/. /home/yunohost.backup/tmp/test5/apps/kanboard/yunohost
    ++ sudo yunohost app setting kanboard domain
    + domain=xxxx
    + sudo cp -a /etc/nginx/conf.d/xxxxxxxxxx/kanboard.conf /home/yunohost.backup/tmp/test5/apps/kanboard/nginx.conf